### PR TITLE
Basic implementation of Survival Hunter rotation

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -73,7 +73,7 @@ local _survivalSpells = {
 	WildfireBomb = 259495,
 	VipersVenom = 268552,
 	SerpentSting = 259491,
-	MongooseBite = 259388,
+	MongooseBite = 259387,
 	RaptorStrike = 186270
 }
 

--- a/main.lua
+++ b/main.lua
@@ -73,7 +73,7 @@ local _survivalSpells = {
 	WildfireBomb = 259495,
 	VipersVenom = 268552,
 	SerpentSting = 259491,
-	MongooseFury = 259388,
+	MongooseBite = 259388,
 	RaptorStrike = 186270
 }
 
@@ -248,8 +248,8 @@ function Hunter:Survival(timeShift, currentSpell, gcd, talents)
 	end
 
 	if focus > 30 then
-		if talents[_survivalSpells.MongooseFury] then
-			return _survivalSpells.MongooseFury;
+		if talents[_survivalSpells.MongooseBite] then
+			return _survivalSpells.MongooseBite;
 		else
 			return _survivalSpells.RaptorStrike;
 		end

--- a/main.lua
+++ b/main.lua
@@ -71,8 +71,8 @@ local _survivalSpells = {
 	CoordinatedAssault = 266779,
 	KillCommand = 259489,
 	WildfireBomb = 259495,
-	VipersVenom = 268501,
-	SerpentSting = 268423,
+	VipersVenom = 268552,
+	SerpentSting = 259491,
 	MongooseFury = 259388,
 	RaptorStrike = 186270
 }


### PR DESCRIPTION
Initial implementation Icy Veins Single Target Rotation
https://www.icy-veins.com/wow/survival-hunter-pve-dps-rotation-cooldowns-abilities

Expected talent tree:
- 15: Viper's Venom
- 30: Guerilla Tactics
- 45: N/A
- 60: Bloodseeker
- 75: N/A
- 90: Tip of the Spear
- 100: Birds of Prey

Added logic to determine use of Raptor Strike vs Mongoose Bite, but does not perform checks for Mongoose Fury stacks.