### PR TITLE
Update Marksmanship to include Chimaera Shot

### DIFF
--- a/Specialization/Marksmanship.lua
+++ b/Specialization/Marksmanship.lua
@@ -175,7 +175,7 @@ function Hunter:MarksmanshipSt()
 	-- arcane_shot,if=buff.master_marksman.up&buff.trueshot.up&focus+cast_regen<focus.max;
 	if focus >= 15 and (buff[MM.MasterMarksman].up and buff[MM.Trueshot].up and focus + castRegen < focusMax) then
 		if talents[MM.ChimaeraShot] then
-			return MM.ChimaeraShot
+			return MM.ChimaeraShot;
 		end
 		return MM.ArcaneShot;
 	end
@@ -219,7 +219,7 @@ function Hunter:MarksmanshipSt()
 		timeToDie < 5
 	) then
 		if talents[MM.ChimaeraShot] then
-			return MM.ChimaeraShot
+			return MM.ChimaeraShot;
 		end
 		return MM.ArcaneShot;
 	end

--- a/Specialization/Marksmanship.lua
+++ b/Specialization/Marksmanship.lua
@@ -24,6 +24,7 @@ local MM = {
 	AMurderOfCrows   = 131894,
 	SerpentSting     = 271788,
 	ArcaneShot       = 185358,
+	ChimaeraShot     = 53209,
 	MasterMarksman   = 269576,
 	Streamline       = 260367,
 	PreciseShots     = 260240,
@@ -173,6 +174,9 @@ function Hunter:MarksmanshipSt()
 
 	-- arcane_shot,if=buff.master_marksman.up&buff.trueshot.up&focus+cast_regen<focus.max;
 	if focus >= 15 and (buff[MM.MasterMarksman].up and buff[MM.Trueshot].up and focus + castRegen < focusMax) then
+		if talents[MM.ChimaeraShot] then
+			return MM.ChimaeraShot
+		end
 		return MM.ArcaneShot;
 	end
 
@@ -214,6 +218,9 @@ function Hunter:MarksmanshipSt()
 		) and not buff[MM.Trueshot].up or
 		timeToDie < 5
 	) then
+		if talents[MM.ChimaeraShot] then
+			return MM.ChimaeraShot
+		end
 		return MM.ArcaneShot;
 	end
 


### PR DESCRIPTION
#### Context

Chimaera Shot is available and viable in Shadowlands for Marksmanship Hunters. It replaces Arcane Shot when talented. I'm making a simple change, to return Chimaera Shot when talented. This needs further vetting as the optimal use conditions for this action, as the change is only intended to "unbreak" conditions where Arcane Shot is not available.

Please note, this is my first attempt at contributing to this or any other WoW addon. Feedback welcome.

#### References

Note that Chimaera Shot is the recommend talent in the [Icy Veins MM Hunter Leveling Guide](https://www.icy-veins.com/wow/marksmanship-hunter-leveling-guide).